### PR TITLE
gh-130474: Create and implement flaky resource

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -39,6 +39,7 @@ from test.support import script_helper
 from test.support import socket_helper
 from test.support import threading_helper
 from test.support import warnings_helper
+from test.support import requires_resource
 
 
 # Skip tests if _multiprocessing wasn't built.

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -33,7 +33,7 @@ EXIT_TIMEOUT = 120.0
 
 
 ALL_RESOURCES = ('audio', 'curses', 'largefile', 'network',
-                 'decimal', 'cpu', 'subprocess', 'urlfetch', 'gui', 'walltime')
+                 'decimal', 'cpu', 'subprocess', 'urlfetch', 'gui', 'walltime', 'flaky')
 
 # Other resources excluded from --use=all:
 #

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -8,6 +8,7 @@ import warnings
 
 from test import support
 from test.support import is_wasi, Py_DEBUG
+from test.support import requires_resource
 from test.support.os_helper import (TESTFN, skip_unless_symlink,
                                     can_symlink, create_empty_file, change_cwd)
 
@@ -521,7 +522,7 @@ class SymlinkLoopGlobTests(unittest.TestCase):
     # gh-109959: On Linux, glob._isdir() and glob._lexists() can return False
     # randomly when checking the "link/" symbolic link.
     # https://github.com/python/cpython/issues/109959#issuecomment-2577550700
-    @unittest.skip("flaky test")
+    @support.requires_resource('flaky')
     def test_selflink(self):
         tempdir = TESTFN + "_dir"
         os.makedirs(tempdir)

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -13,6 +13,7 @@ import threading
 import time
 import unittest
 from test import support
+from test.support import requires_resource
 from test.support import (
     is_apple, is_apple_mobile, os_helper, threading_helper
 )
@@ -1353,6 +1354,7 @@ class StressTest(unittest.TestCase):
     @unittest.skipUnless(hasattr(signal, "SIGUSR1"),
                          "test needs SIGUSR1")
     @threading_helper.requires_working_threading()
+    @support.requires_resource('flaky')
     def test_stress_modifying_handlers(self):
         # bpo-43406: race condition between trip_signal() and signal.signal
         signum = signal.SIGUSR1

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -23,6 +23,7 @@ from test.support import socket_helper
 from test.support import threading_helper
 from test.support import asyncore
 from test.support import smtpd
+from test.support import requires_resource
 from unittest.mock import Mock
 
 
@@ -374,6 +375,7 @@ class DebuggingServerTests(unittest.TestCase):
                                       b'RCPT DATA RSET NOOP QUIT VRFY')
         smtp.quit()
 
+    @support.requires_resource('flaky')
     def testSend(self):
         # connect and send mail
         m = 'A test message'


### PR DESCRIPTION

# Initial implementation of flaky resource

I've created the resource and implemented it in some obvious places where comments pointed to flaky tests. There were certain tests I left alone as although they were marked flaky by inline comments, there were other decorators addressing this, for example certain tests that were marked as being flaky without the GIL are already marked with the `@support.requires_gil_enabled` decorator which I think makes more sense.

As with other resources, the use-case for decorating tests is just:
```
from test.support import requires_resource

@requires_resource('flaky')
def test_flaky_test():
...
```

With this set-up, in CI environments we can configure the CI to run flaky tests separately with retries using something like:
`python -m test --use=flaky --rerun`
which will automatically retry failed flaky tests.